### PR TITLE
Review version for WSL (Win) installation

### DIFF
--- a/docs/Howtos/linux.md
+++ b/docs/Howtos/linux.md
@@ -27,7 +27,7 @@ sudo apt install m4 make gcc
 Opam, the Ocaml package manager is also a pre-requisite.  The recommended installation method script requires elevated privileges, as it defaults `/usr/local/bin`.  If you do not have an existing Opam installation, you can change this by modifying `DEFAUL_BINDIR` inside the script, however, if you do, it will not work.
 
 ```bash
-sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+bash -c "sh <(curl -fsSL https://opam.ocaml.org/install.sh)"
 ```
 ### 2. Installing  compilers (local user installation) and packages
 
@@ -67,7 +67,7 @@ fi
 ```
 
 > [!NOTE]- Using a different OCaml version simultaneously with OCaml 5
-> The above script will create a switch for OCaml 5, but you could use different versions if you need them with `ocaml switch`.
+> The above script will create a switch for OCaml 5, but you could use different versions if you need them with `opam switch`.
 > 
 
 The following script takes care of the **Miking and TreePPL compilers and packages**:
@@ -78,19 +78,28 @@ git clone -n https://github.com/treeppl/miking.git
 cd miking
 git checkout 24505bd
 make install
+export PATH="$HOME/.local/bin:$PATH"
+cd ..
 
 git clone -n https://github.com/treeppl/miking-dppl.git
 cd miking-dppl
-git checkout 680ea76
+git checkout 70fabcc
 make install
+export MCORE_LIBS="coreppl=$HOME/.local/src/coreppl/"
+cd ..
 
 git clone https://github.com/treeppl/treeppl.git
-(cd treeppl && make install)
+cd treeppl
+make install
+export MCORE_LIBS="$MCORE_LIBS:treeppl=$HOME/.local/src/treeppl/"
+cd ..
 
 git clone https://github.com/treeppl/treeppl-python.git
-(cd treeppl-python && pip install -e .)
+cd treeppl-python 
+pip install --breaking-system-packages -e .
+cd ..
 
-pip install matplotlib seaborn
+pip install --breaking-system-packages matplotlib seaborn
 ```
 
 This script will create three source directories in the directory where you execute it: `miking`, `miking-dppl` and `treeppl` and instruct you how to set up the environment variables.  If you don’t want to do any TreePPL development, you can remove `miking` and `miking-dppl` install sources, but you don’t have to.


### PR DESCRIPTION
- `sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)` : don't work. now follow the guideline of [opam installation guide](https://opam.ocaml.org/doc/Install.html)
- `ocaml switch` : typo change to `opam switch`
- `git checkout 680ea76 `: point now to the last commit. **Do we really need to do that now the treeppl repo is update ?**
- `export PATH ...` added after each installation to permit the script to flow without error
- `pip install -e .` : need to be replace (in the newest version of Unbuntu at least) by pip install --breaking-system-packages -e .