### PR TITLE
Fix urls to not be quite as absolute

### DIFF
--- a/docs/tutorials/treeppl-intro.md
+++ b/docs/tutorials/treeppl-intro.md
@@ -7,6 +7,6 @@ sidebar_label: A Basic Tutorial to Probabilistic Programming in TreePPL
 
 The foundation of TreePPL is based on the principles of probabilistic Programming, a programmatic way of specifying Bayesian probabilistic models.
 
-In this section, you can find a basic tutorial on how to do modeling using probabilistic programming in TreePPL. The goal of the tutorial is to demonstrate simple probabilistic programming in TreePPL, not to give a complete view of how to do phylogenetic modeling. For the basic tutorial, please see the [following slides](http://www.treeppl.org/courses/treeppl-tutorial.pdf).
+In this section, you can find a basic tutorial on how to do modeling using probabilistic programming in TreePPL. The goal of the tutorial is to demonstrate simple probabilistic programming in TreePPL, not to give a complete view of how to do phylogenetic modeling. For the basic tutorial, please see the [following slides](/courses/treeppl-tutorial.pdf).
 
-As part of the tutorial, you can also find exercises in a Jupyter notebook. Please start by downloading the [exercises here](http://www.treeppl.org/courses/basic-tutorial.zip). Suggestions for solutions can also be [found here](http://www.treeppl.org/courses/basic-tutorial-solutions.zip).
+As part of the tutorial, you can also find exercises in a Jupyter notebook. Please start by downloading the [exercises here](/courses/basic-tutorial.zip). Suggestions for solutions can also be [found here](/courses/basic-tutorial-solutions.zip).


### PR DESCRIPTION
Use URLs relative to the instance rather than an absolute URL to treeppl.org.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
